### PR TITLE
Don't upgrade the evil packages

### DIFF
--- a/package-upgrader/package-upgrader.sh
+++ b/package-upgrader/package-upgrader.sh
@@ -4,9 +4,9 @@
 echo "Updating package list..."
 opkg update > /dev/null
 
-if [ `opkg list-upgradable | cut -d " " -f1 | grep -v "kmod-" | wc -l` -gt 0 ]; then
+if [ `opkg list-upgradable | cut -d " " -f1 | grep -v "kmod-" | grep -v "netifd" | grep -v "Multiple" | wc -l` -gt 0 ]; then
   echo "Available updates:"
-  opkg list-upgradable | grep -v "kmod-"
+  opkg list-upgradable | grep -v "kmod-" | grep -v "netifd" | grep -v "Multiple"
   echo ""
 
   valid=0
@@ -18,7 +18,7 @@ if [ `opkg list-upgradable | cut -d " " -f1 | grep -v "kmod-" | wc -l` -gt 0 ]; 
         valid=1
         echo ""
         echo "Upgrading all packages..."
-        opkg list-upgradable | cut -d " " -f1 | grep -v "kmod-" | xargs -r opkg upgrade
+        opkg list-upgradable | cut -d " " -f1 | grep -v "kmod-" | grep -v "netifd" | grep -v "Multiple" | xargs -r opkg upgrade
         ;;
       n|N)
         valid=1


### PR DESCRIPTION
Upgrading the package `netifd` seems to have an affinity for soft-bricking my router. Every time it's upgraded, a TFTP flash is needed.

TODO? Refactor the exclusion list so it's more maintainable.